### PR TITLE
Add help.rs and extend help command with categories and detailed usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,13 @@ The following Python-like utility functions are included.
 ```
 $ cargo run
 >>>help
-[will give the structure of the operations and functions]
+[will give the structure of the operations and functions with last line:Type any operator or function name to see its usage (e.g. `pow`, `+`, `log`, etc.)]
+>>> log
+Usage:log(base: number, value: number) -> number
+>>> +
+Usage:+: number + number -> number
+>>> pi
+Usage:Constant: π = 3.141592...
 >>> 1 + 1
  2
 >>> factorial(n) = factorial(n - 1) * n if n > 0 else 1

--- a/README.md
+++ b/README.md
@@ -98,6 +98,8 @@ The following Python-like utility functions are included.
 
 ```
 $ cargo run
+>>>help
+[will give the structure of the operations and functions]
 >>> 1 + 1
  2
 >>> factorial(n) = factorial(n - 1) * n if n > 0 else 1

--- a/src/help.rs
+++ b/src/help.rs
@@ -1,0 +1,86 @@
+use std::collections::HashMap;
+
+pub fn get_help_categories() -> HashMap<&'static str, Vec<&'static str>>{
+    let mut help = HashMap::new();
+
+    help.insert("Arithmetic", vec!["+", "-", "*", "/", "pow", "abs", "sqrt", "round", "ceil","floor","sign", "float", "exp"]);
+    help.insert("Functions", vec![
+        "log", "log10", "log2", "ln", 
+        "sin", "cos", "tan", "asin", "acos", "atan", "atan2", "hypot",
+        "max", "min", "range", "map", "linspace", "sort", "length"
+    ]);
+    help.insert("Comparison", vec!["<", ">", "<=", ">=", "==", "!="]);
+    help.insert("Boolean", vec!["and", "or", "not"]);
+    help.insert("Constants", vec!["pi", "e", "inf", "nan"]);
+
+    help
+
+}
+
+pub fn get_function_details(name: &str) -> Option<&'static str>{
+    match name{
+        "+" => Some("+: number + number -> number"),
+        "-" => Some("-: number - number -> number"),
+        "*" => Some("*: number * number -> number"),
+        "/" => Some("/: number / number -> number"),
+
+        "pow" => Some("pow(base: number, exponent: number) -> number"),
+        "abs" => Some("abs(x: number) -> number"),
+        "sqrt" => Some("sqrt(x: number) -> number"),
+        "round" => Some("round(x: number) -> number"),
+        "ceil" => Some("ceil(x: number) -> number"),
+        "floor" => Some("floor(x: number) -> number"),
+        "sign" => Some("sign(x: number) -> number (-1, 0, 1)"),
+        "float" => Some("float(x: number) -> number"),
+        "exp" => Some("exp(x: number) -> number (e^x)"),
+
+         // Logarithmic and Trigonometric
+        "log" => Some("log(base: number, value: number) -> number"),
+        "log10" => Some("log10(x: number) -> number"),
+        "log2" => Some("log2(x: number) -> number"),
+        "ln" => Some("ln(x: number) -> number"),
+
+        "sin" => Some("sin(x: radians) -> number"),
+        "cos" => Some("cos(x: radians) -> number"),
+        "tan" => Some("tan(x: radians) -> number"),
+        "asin" => Some("asin(x: number) -> radians"),
+        "acos" => Some("acos(x: number) -> radians"),
+        "atan" => Some("atan(x: number) -> radians"),
+        "atan2" => Some("atan2(y: number, x: number) -> radians"),
+        "hypot" => Some("hypot(x: number, y: number) -> number"),
+
+        // Utility functions
+        "max" => Some("max(a: number, b: number, ...) or max([a, b, ...]) -> number"),
+        "min" => Some("min(a: number, b: number, ...) or min([a, b, ...]) -> number"),
+        "range" => Some("range(start: number, end: number) or range(end: number) -> [number]"),
+        "map" => Some("map(f: function, list: [value]) -> [value]"),
+        "linspace" => Some("linspace(start: number, end: number, count: number) -> [number]"),
+        "sort" => Some("sort(list: [value]) -> [value]"),
+        "length" => Some("length(list: [value]) -> number"),
+
+        // Comparison
+        "<" => Some("<: a < b -> bool"),
+        ">" => Some(">: a > b -> bool"),
+        "<=" => Some("<=: a <= b -> bool"),
+        ">=" => Some(">=: a >= b -> bool"),
+        "==" => Some("<: a == b -> bool"),
+        "!=" => Some("<: a != b -> bool"),
+
+        // Boolean
+        "and" => Some("and(a: bool, b: bool) -> bool"),
+        "or" => Some("or(a: bool, b: bool) -> bool"),
+        "not" => Some("not(a: bool) -> bool"),
+
+        // Constants
+        "pi" => Some("Constant: π = 3.141592..."),
+        "e" => Some("Constant: e = 2.71828..."),
+        "inf" => Some("Constant: Positive infinity"),
+        "nan" => Some("Constant: Not-a-Number"),
+
+        // "and" | "&&" => Some("and(a: bool, b: bool) → bool"),
+        // "or"  | "||" => Some("or(a: bool, b: bool) → bool"),
+        // "not" | "!"  => Some("not(a: bool) → bool"),
+        _ => None,
+
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,10 +14,12 @@ mod eval;
 mod funcs;
 mod lexer;
 mod parser;
+mod help;
 
 use eval::{evaluate, Context, EvalError, Value};
 use lexer::tokenize;
 use parser::{parse, ParseError, Span};
+use help::{get_help_categories, get_function_details};
 
 fn clean_input(line: &str) -> String {
     line.chars()
@@ -68,6 +70,12 @@ fn format_value(val: &Value) -> String {
 }
 
 fn execute_line(line: &str, ctx: &mut Context) {
+    //check if user asked for usafe of an operator/function
+    if let Some(help_text) = get_function_details(line){
+        println!("Usage:{}",help_text);
+        return;
+    }
+
     let lexer = tokenize(line.trim());
 
     let root = match parse(lexer) {
@@ -96,6 +104,7 @@ fn main() {
 
     let base = funcs::create();
     let mut ctx = eval::Context::with_parent(&base);
+    println!("For help run command: {}", "help");
 
     loop {
         output.write_all(b">>> ").unwrap();
@@ -110,6 +119,22 @@ fn main() {
         }
 
         if line.is_empty() {
+            continue;
+        }
+
+        if line == "help"{
+            println!("\nAvailable operations:\n");
+
+            let help = get_help_categories();
+            for (category, items) in help.iter(){
+                println!("{}:", category);
+                for op in items{
+                    println!(" - {}", op);
+                }
+                println!();
+            }
+
+            println!("Type any operator or function name to see its usage (e.g. `pow`, `+`, `log`, etc.)\n");
             continue;
         }
 


### PR DESCRIPTION
Although the README outlines the available commands, operators, and functions, it's more efficient and user-friendly to have this information accessible directly via the command line.

I was exploring and learning from this project, and during that process, I added a `help` module (`help.rs`) that includes:
- Grouped help categories (Arithmetic, Functions, Comparison, Boolean)
- Detailed descriptions and usage formats for each operation and function

Now, users can simply type `help` to:
- Discover all supported operations
- Understand how to use each one, including argument types and expected behavior by running the particular operation, function

This addition improves usability for anyone interacting with the calculator from the terminal.
